### PR TITLE
feat:lane diag aggregator

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml
@@ -4,20 +4,6 @@
       type: diagnostic_aggregator/AnalyzerGroup
       path: control
       analyzers:
-        # autonomous_emergency_braking:
-        #   type: diagnostic_aggregator/AnalyzerGroup
-        #   path: autonomous_emergency_braking
-        #   analyzers:
-        #     performance_monitoring:
-        #       type: diagnostic_aggregator/AnalyzerGroup
-        #       path: performance_monitoring
-        #       analyzers:
-        #         emergency_stop:
-        #           type: diagnostic_aggregator/GenericAnalyzer
-        #           path: emergency_stop
-        #           contains: [": aeb_emergency_stop"]
-        #           timeout: 1.0
-
         control_command_gate:
           type: diagnostic_aggregator/AnalyzerGroup
           path: control_command_gate
@@ -68,48 +54,12 @@
                   contains: [": control_state"]
                   timeout: 1.0
 
-        # external_control:
-        #   type: diagnostic_aggregator/AnalyzerGroup
-        #   path: external_control
-        #   analyzers:
-        #     external_command_selector:
-        #       type: diagnostic_aggregator/AnalyzerGroup
-        #       path: external_command_selector
-        #       analyzers:
-        #         node_alive_monitoring:
-        #           type: diagnostic_aggregator/AnalyzerGroup
-        #           path: node_alive_monitoring
-        #           analyzers:
-        #             heartbeat:
-        #               type: diagnostic_aggregator/GenericAnalyzer
-        #               path: heartbeat
-        #               contains: ["external_cmd_selector: heartbeat"]
-        #               timeout: 1.0
-
-            # local_external_control:
-            #   type: diagnostic_aggregator/AnalyzerGroup
-            #   path: local_external_control
-            #   analyzers:
-            #     device_connection:
-            #       type: diagnostic_aggregator/AnalyzerGroup
-            #       path: device_connection
-            #       analyzers:
-            #         joy_controller_connection:
-            #           type: diagnostic_aggregator/GenericAnalyzer
-            #           path: joy_controller_connection
-            #           contains: [": joy_controller_connection"]
-            #           timeout: 1.0
-
-            # remote_external_control:
-            #   type: diagnostic_aggregator/AnalyzerGroup
-            #   path: remote_external_control
-            #   analyzers:
-            #     network_connection:
-            #       type: diagnostic_aggregator/AnalyzerGroup
-            #       path: network_connection
-            #       analyzers:
-            #         remote_control_topic_status:
-            #           type: diagnostic_aggregator/GenericAnalyzer
-            #           path: remote_control_topic_status
-            #           contains: [": remote_control_topic_status"]
-            #           timeout: 1.0
+            lane_monitoring:                           # 追加
+              type: diagnostic_aggregator/AnalyzerGroup
+              path: lane_monitoring
+              analyzers:
+                lane_status:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: lane_status
+                  contains: ["lane_width_calculator: lane_status"]
+                  timeout: 1.0


### PR DESCRIPTION
# 変更点
lane内外判定のdiagnosticが出ているので、そのtopicをautowareの形式に合わせて集計する
lane_statusとしてlane_statusが出力される

- left_offset
- right_offset
- path_ids(経路計画されているlane id)
- current_lanelets(現在車両がいるlane id)
- judging_lanelets(判定に用いているlane id)

![image](https://github.com/user-attachments/assets/6ce5ed68-e974-4e9b-a5ac-5f2a8519190d)

以上
