### PR TITLE
feat: route select by lane id

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -8,7 +8,7 @@
       <group>
         <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py">
           <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
-          <arg name="use_multithread" value="true"/>
+          <arg name="use_multithread" value="false"/>
           <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
           <arg name="container_name" value="$(var pointcloud_container_name)"/>
           <arg name="use_experimental_lane_change_function" value="$(var use_experimental_lane_change_function)"/>

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -170,7 +170,7 @@ private:
   lanelet::ConstLanelet updateRootLanelet(const std::shared_ptr<PlannerData> & data) const
   {
     lanelet::ConstLanelet ret{};
-    data->route_handler->getClosestLaneletWithinRoute(data->self_odometry->pose.pose, &ret);
+    data->route_handler->getDrivingLanelet(data->self_odometry->pose.pose, &ret);
     RCLCPP_DEBUG(logger_, "update start lanelet. id:%ld", ret.id());
     return ret;
   }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -58,6 +58,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     planner_data_ = std::make_shared<PlannerData>();
     planner_data_->parameters = getCommonParam();
     planner_data_->drivable_area_expansion_parameters.init(*this);
+    planner_data_->route_handler->setPublisher(this);
   }
 
   // publisher
@@ -98,7 +99,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     "~/input/lateral_offset", 1, std::bind(&BehaviorPathPlannerNode::onLateralOffset, this, _1),
     createSubscriptionOptions(this));
   operation_mode_subscriber_ = create_subscription<OperationModeState>(
-    "/system/operation_mode/state", 1,
+    "/system/operation_mode/state", rclcpp::QoS{1}.transient_local(),
     std::bind(&BehaviorPathPlannerNode::onOperationMode, this, _1),
     createSubscriptionOptions(this));
   scenario_subscriber_ = create_subscription<Scenario>(
@@ -1016,6 +1017,14 @@ bool BehaviorPathPlannerNode::isDataReady()
     return missing("operation_mode");
   }
 
+  if (planner_data_->route_handler->isHandlerReady()) {
+    lanelet::ConstLanelet driving_lanelet;
+    if (!planner_data_->route_handler->getDrivingLanelet(
+          planner_data_->self_odometry->pose.pose, &driving_lanelet)) {
+      return missing("driving_lanelet (outside route polygon)");
+    }
+  }
+
   return true;
 }
 
@@ -1110,6 +1119,7 @@ void BehaviorPathPlannerNode::run()
   // NOTE: In order to keep backward_path_length at least, resampling interval is added to the
   // backward.
   const auto current_pose = planner_data_->self_odometry->pose.pose;
+  planner_data_->route_handler->publishDrivingLaneletId(current_pose);
   const size_t current_seg_idx = planner_data_->findEgoSegmentIndex(path->points);
   path->points = motion_utils::cropPoints(
     path->points, current_pose.position, current_seg_idx,
@@ -1357,6 +1367,9 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(
   // TODO(Horibe) do some error handling when path is not available.
 
   auto path = bt_output.path ? bt_output.path : planner_data->prev_output_path;
+  if (!path) {
+    path = std::make_shared<PathWithLaneId>();
+  }
   path->header = planner_data->route_handler->getRouteHeader();
   path->header.stamp = this->now();
   RCLCPP_DEBUG(

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1034,6 +1034,7 @@ void BehaviorPathPlannerNode::run()
     return;
   }
 
+  RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 10000, "[BPP] run() started (throttle 10s)");
   RCLCPP_DEBUG(get_logger(), "----- BehaviorPathPlannerNode start -----");
 
   // behavior_path_planner runs only in LANE DRIVING scenario.
@@ -1109,6 +1110,12 @@ void BehaviorPathPlannerNode::run()
 #endif
   // update planner data
   planner_data_->prev_output_path = path;
+
+  if (path->points.empty()) {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
+    return;
+  }
 
   // compute turn signal
   computeTurnSignal(planner_data_, *path, output);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -391,7 +391,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     }
 
     lanelet::ConstLanelet overhang_lanelet;
-    if (!rh->getClosestLaneletWithinRoute(object_closest_pose, &overhang_lanelet)) {
+    if (!rh->getDrivingLanelet(object_closest_pose, &overhang_lanelet)) {
       continue;
     }
 
@@ -2616,7 +2616,7 @@ lanelet::ConstLanelets AvoidanceModule::getAdjacentLane(
   }
 
   lanelet::ConstLanelet current_lane;
-  if (!rh->getClosestLaneletWithinRoute(getEgoPose(), &current_lane)) {
+  if (!rh->getDrivingLanelet(getEgoPose(), &current_lane)) {
     RCLCPP_ERROR(
       rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
       "failed to find closest lanelet within route!!!");

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -118,7 +118,7 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
   reference_path.header = route_handler->getRouteHeader();
 
   lanelet::ConstLanelet current_lane;
-  if (!planner_data_->route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
+  if (!planner_data_->route_handler->getDrivingLanelet(current_pose, &current_lane)) {
     RCLCPP_ERROR_THROTTLE(
       getLogger(), *clock_, 5000, "failed to find closest lanelet within route!!!");
     return reference_path;  // TODO(Horibe)

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -211,7 +211,7 @@ void SideShiftModule::updateData()
   const auto & p = planner_data_->parameters;
 
   lanelet::ConstLanelet current_lane;
-  if (!route_handler->getClosestLaneletWithinRoute(reference_pose, &current_lane)) {
+  if (!route_handler->getDrivingLanelet(reference_pose, &current_lane)) {
     RCLCPP_ERROR_THROTTLE(
       getLogger(), *clock_, 5000, "failed to find closest lanelet within route!!!");
   }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1564,7 +1564,7 @@ std::shared_ptr<PathWithLaneId> generateCenterLinePath(
   const auto & pose = planner_data->self_odometry->pose.pose;
 
   lanelet::ConstLanelet current_lane;
-  if (!route_handler->getClosestLaneletWithinRoute(pose, &current_lane)) {
+  if (!route_handler->getDrivingLanelet(pose, &current_lane)) {
     RCLCPP_ERROR(
       rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
       "failed to find closest lanelet within route!!!");
@@ -1601,7 +1601,7 @@ lanelet::ConstLineStrings3d getMaximumDrivableArea(
   const auto & ego_pose = planner_data->self_odometry->pose.pose;
 
   lanelet::ConstLanelet current_lane;
-  if (!route_handler->getClosestLaneletWithinRoute(ego_pose, &current_lane)) {
+  if (!route_handler->getDrivingLanelet(ego_pose, &current_lane)) {
     RCLCPP_ERROR(
       rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
       "failed to find closest lanelet within route!!!");
@@ -1838,7 +1838,7 @@ lanelet::ConstLanelets getCurrentLanes(const std::shared_ptr<const PlannerData> 
   const auto & common_parameters = planner_data->parameters;
 
   lanelet::ConstLanelet current_lane;
-  if (!route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
+  if (!route_handler->getDrivingLanelet(current_pose, &current_lane)) {
     // RCLCPP_ERROR(getLogger(), "failed to find closest lanelet within route!!!");
     std::cerr << "failed to find closest lanelet within route!!!" << std::endl;
     return {};  // TODO(Horibe) what should be returned?
@@ -1907,7 +1907,7 @@ lanelet::ConstLanelets calcLaneAroundPose(
   const double backward_length)
 {
   lanelet::ConstLanelet current_lane;
-  if (!route_handler->getClosestLaneletWithinRoute(pose, &current_lane)) {
+  if (!route_handler->getDrivingLanelet(pose, &current_lane)) {
     RCLCPP_ERROR(
       rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
       "failed to find closest lanelet within route!!!");

--- a/planning/mission_planner/CMakeLists.txt
+++ b/planning/mission_planner/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(mission_planner)
 
 find_package(autoware_cmake REQUIRED)
+find_package(iino_msgs REQUIRED)
 autoware_package()
 
 ament_auto_add_library(goal_pose_visualizer_component SHARED

--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -32,6 +32,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>vehicle_info_util</depend>
+  <depend>iino_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -75,7 +75,9 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   sub_odometry_ = create_subscription<Odometry>(
     "/localization/kinematic_state", rclcpp::QoS(1),
     std::bind(&MissionPlanner::on_odometry, this, std::placeholders::_1));
-
+  sub_lanelet_id_route_ = create_subscription<LaneletIdRoute>(
+    "~/input/lanelet_id_route", rclcpp::QoS(1),
+    std::bind(&MissionPlanner::on_lanelet_id_route, this, std::placeholders::_1));
   const auto durable_qos = rclcpp::QoS(1).transient_local();
   pub_marker_ = create_publisher<MarkerArray>("debug/route_marker", durable_qos);
 
@@ -236,6 +238,90 @@ void MissionPlanner::on_set_route_points(
   change_route(route);
   change_state(RouteState::Message::SET);
   res->status.success = true;
+}
+
+void MissionPlanner::on_lanelet_id_route(const LaneletIdRoute::ConstSharedPtr msg)
+{
+  if (!odometry_) {
+    RCLCPP_WARN(get_logger(), "The vehicle pose is not received.");
+    return;
+  }
+
+  if (msg->lanelet_ids.empty()) {
+    RCLCPP_WARN(get_logger(), "Received empty lanelet id list.");
+    return;
+  }
+
+  // route を強制上書き
+  change_route();
+  change_state(RouteState::Message::UNSET);
+
+  PoseStamped goal_pose_stamped;
+  goal_pose_stamped.header = msg->header;
+  goal_pose_stamped.pose = msg->goal;
+  const auto goal_pose = transform_pose(goal_pose_stamped).pose;
+
+  LaneletRoute route;
+  route.start_pose = odometry_->pose.pose;
+  route.goal_pose = goal_pose;
+  route.header.stamp = msg->header.stamp;
+  route.header.frame_id = map_frame_;
+  route.uuid.uuid = generate_random_id();
+
+  // 1. 固定 lanelet 列をそのまま積む
+  for (const auto & id : msg->lanelet_ids) {
+    LaneletSegment segment;
+    segment.preferred_primitive.id = id;
+    segment.preferred_primitive.primitive_type = "lane";
+    segment.primitives.push_back(segment.preferred_primitive);
+    route.segments.push_back(segment);
+  }
+
+  // 2. 補完部分
+  if (msg->allow_auto_connect) {
+    PlannerPlugin::RoutePoints points;
+
+    // 固定 route の最後から goal へ補完したいので、
+    // 本当は「最後の lanelet 上の終端pose」を入れたい。
+    // ただし最小変更で済ませるなら、いったん最後の固定区間の代表点を
+    // planner 側で解決できるようにする必要がある。
+    //
+    // もし last_fixed_pose を作れる helper があるならそれを使う:
+    //   const auto last_fixed_pose = get_last_pose_from_lanelet_id(msg->lanelet_ids.back());
+    //
+    // 今回は helper がある前提で書く。
+    const auto last_fixed_pose = get_last_pose_from_lanelet_id(msg->lanelet_ids.back());
+
+    points.push_back(last_fixed_pose);
+    points.push_back(goal_pose);
+
+    LaneletRoute extra_route = planner_->plan(points);
+    if (extra_route.segments.empty()) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Auto-complement route is empty. Use only fixed lanelet_ids route.");
+    } else {
+      // 先頭 segment が固定 route の最後と重複することがあるので除去
+      std::size_t start_index = 0;
+      if (!route.segments.empty() && !extra_route.segments.empty()) {
+        const auto & fixed_last = route.segments.back().preferred_primitive;
+        const auto & extra_first = extra_route.segments.front().preferred_primitive;
+        if (
+          fixed_last.id == extra_first.id &&
+          fixed_last.primitive_type == extra_first.primitive_type)
+        {
+          start_index = 1;
+        }
+      }
+
+      for (std::size_t i = start_index; i < extra_route.segments.size(); ++i) {
+        route.segments.push_back(convert(extra_route.segments[i]));
+      }
+    }
+  }
+
+  change_route(route);
+  change_state(RouteState::Message::SET);
 }
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -76,7 +76,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
     "/localization/kinematic_state", rclcpp::QoS(1),
     std::bind(&MissionPlanner::on_odometry, this, std::placeholders::_1));
   sub_lanelet_id_route_ = create_subscription<LaneletIdRoute>(
-    "~/input/lanelet_id_route", rclcpp::QoS(1),
+    "/iino/lanelet_id_route", rclcpp::QoS(1),
     std::bind(&MissionPlanner::on_lanelet_id_route, this, std::placeholders::_1));
   const auto durable_qos = rclcpp::QoS(1).transient_local();
   pub_marker_ = create_publisher<MarkerArray>("debug/route_marker", durable_qos);
@@ -275,49 +275,6 @@ void MissionPlanner::on_lanelet_id_route(const LaneletIdRoute::ConstSharedPtr ms
     segment.preferred_primitive.primitive_type = "lane";
     segment.primitives.push_back(segment.preferred_primitive);
     route.segments.push_back(segment);
-  }
-
-  // 2. 補完部分
-  if (msg->allow_auto_connect) {
-    PlannerPlugin::RoutePoints points;
-
-    // 固定 route の最後から goal へ補完したいので、
-    // 本当は「最後の lanelet 上の終端pose」を入れたい。
-    // ただし最小変更で済ませるなら、いったん最後の固定区間の代表点を
-    // planner 側で解決できるようにする必要がある。
-    //
-    // もし last_fixed_pose を作れる helper があるならそれを使う:
-    //   const auto last_fixed_pose = get_last_pose_from_lanelet_id(msg->lanelet_ids.back());
-    //
-    // 今回は helper がある前提で書く。
-    const auto last_fixed_pose = get_last_pose_from_lanelet_id(msg->lanelet_ids.back());
-
-    points.push_back(last_fixed_pose);
-    points.push_back(goal_pose);
-
-    LaneletRoute extra_route = planner_->plan(points);
-    if (extra_route.segments.empty()) {
-      RCLCPP_WARN(
-        get_logger(),
-        "Auto-complement route is empty. Use only fixed lanelet_ids route.");
-    } else {
-      // 先頭 segment が固定 route の最後と重複することがあるので除去
-      std::size_t start_index = 0;
-      if (!route.segments.empty() && !extra_route.segments.empty()) {
-        const auto & fixed_last = route.segments.back().preferred_primitive;
-        const auto & extra_first = extra_route.segments.front().preferred_primitive;
-        if (
-          fixed_last.id == extra_first.id &&
-          fixed_last.primitive_type == extra_first.primitive_type)
-        {
-          start_index = 1;
-        }
-      }
-
-      for (std::size_t i = start_index; i < extra_route.segments.size(); ++i) {
-        route.segments.push_back(convert(extra_route.segments[i]));
-      }
-    }
   }
 
   change_route(route);

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -26,6 +26,7 @@
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
+#include <iino_msgs/msg/lanelet_id_route.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -47,6 +48,7 @@ using ClearRoute = planning_interface::ClearRoute;
 using Route = planning_interface::Route;
 using RouteState = planning_interface::RouteState;
 using Odometry = nav_msgs::msg::Odometry;
+using LaneletIdRoute = iino_msgs::msg::LaneletIdRoute;
 
 class MissionPlanner : public rclcpp::Node
 {
@@ -65,6 +67,10 @@ private:
   rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
   Odometry::ConstSharedPtr odometry_;
   void on_odometry(const Odometry::ConstSharedPtr msg);
+
+  // 追加: lanelet id列 + goal を topic で受ける
+  rclcpp::Subscription<LaneletIdRoute>::SharedPtr sub_lanelet_id_route_;
+  void on_lanelet_id_route(const LaneletIdRoute::ConstSharedPtr msg);
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
   void change_route();

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -29,6 +29,7 @@
 #include <autoware_planning_msgs/msg/lanelet_segment.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
+#include <std_msgs/msg/int32.hpp>
 
 #include <lanelet2_routing/Route.h>
 #include <lanelet2_routing/RoutingCost.h>
@@ -88,6 +89,8 @@ public:
   void setMap(const HADMapBin & map_msg);
   void setRoute(const LaneletRoute & route_msg);
   void setRouteLanelets(const lanelet::ConstLanelets & path_lanelets);
+  void setPublisher(rclcpp::Node * node);
+  void publishDrivingLaneletId(const Pose & current_pose) const;
 
   // const methods
 
@@ -289,8 +292,8 @@ public:
   int getNumLaneToPreferredLane(
     const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
 
-  bool getClosestLaneletWithinRoute(
-    const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
+  bool getDrivingLanelet(
+    const Pose & search_pose, lanelet::ConstLanelet * driving_lanelet) const;
 
   lanelet::ConstLanelet getLaneletsFromId(const lanelet::Id id) const;
   lanelet::ConstLanelets getLaneletsFromIds(const lanelet::Ids & ids) const;
@@ -348,6 +351,7 @@ private:
   LaneletRoute route_msg_;
 
   rclcpp::Logger logger_{rclcpp::get_logger("route_handler")};
+  std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Int32>> lanelet_id_pub_;
 
   bool is_route_msg_ready_{false};
   bool is_map_msg_ready_{false};

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -39,6 +39,8 @@
 #include <limits>
 #include <memory>
 #include <vector>
+#include <optional>
+#include <unordered_map>
 
 namespace route_handler
 {
@@ -401,6 +403,10 @@ private:
   lanelet::ConstLanelets getNeighborsWithinRoute(const lanelet::ConstLanelet & lanelet) const;
   std::vector<lanelet::ConstLanelets> getLaneSection(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getNextLaneSequence(const lanelet::ConstLanelets & lane_sequence) const;
+  
+  std::unordered_map<lanelet::Id, size_t> route_index_map_;
+  mutable std::optional<size_t> last_closest_route_index_;
+  size_t max_lane_jump_{2};
 
   // for path
 

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -359,7 +359,7 @@ std::vector<lanelet::ConstLanelet> RouteHandler::getLanesBeforePose(
   const geometry_msgs::msg::Pose & pose, const double length) const
 {
   lanelet::ConstLanelet pose_lanelet;
-  if (!getClosestLaneletWithinRoute(pose, &pose_lanelet)) {
+  if (!getDrivingLanelet(pose, &pose_lanelet)) {
     return std::vector<lanelet::ConstLanelet>{};
   }
 
@@ -723,65 +723,59 @@ lanelet::ConstLanelets RouteHandler::getShoulderLaneletSequence(
   return lanelet_sequence;
 }
 
-bool RouteHandler::getClosestLaneletWithinRoute(
-  const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const
+bool RouteHandler::getDrivingLanelet(
+  const Pose & search_pose, lanelet::ConstLanelet * driving_lanelet) const
 {
-  std::vector<lanelet::ConstLanelet> candidates;
-  candidates.reserve(route_lanelets_.size());
+  const lanelet::BasicPoint2d search_point(search_pose.position.x, search_pose.position.y);
+
+  // ポリゴン内の候補のうち route_index_map_ のインデックスが最小（スタートに最も近い）ものを返す
+  // ※ setRouteLanelets は unordered_set からレーンを構築するため route_lanelets_ の配列順はルート順と
+  //   は限らない。配列順に最初のヒットを返すのではなく、インデックス最小で選ぶことで順序非依存にする。
+  std::optional<lanelet::ConstLanelet> best;
+  size_t min_idx = std::numeric_limits<size_t>::max();
 
   for (const auto & llt : route_lanelets_) {
-    auto it = route_index_map_.find(llt.id());
-    if (it == route_index_map_.end()) {
+    if (!lanelet::geometry::inside(llt, search_point)) {
       continue;
     }
-
-    if (last_closest_route_index_) {
-      const auto idx = it->second;
-      const auto last = *last_closest_route_index_;
-
-      // 飛びすぎ禁止
-      if (idx + 1 < last) {
-        continue;
+    auto it = route_index_map_.find(llt.id());
+    if (it == route_index_map_.end()) {
+      // route_index_map_ 未設定（setRouteLanelets 経由）の場合は最初のヒットを採用
+      if (!best) {
+        best = llt;
       }
-      if (idx > last + max_lane_jump_) {
-        continue;
-      }
+      continue;
     }
-
-    candidates.push_back(llt);
+    if (it->second < min_idx) {
+      min_idx = it->second;
+      best = llt;
+    }
   }
 
-  if (candidates.empty()) {
-    candidates = route_lanelets_;
+  if (best) {
+    *driving_lanelet = *best;
+    if (min_idx != std::numeric_limits<size_t>::max()) {
+      last_closest_route_index_ = min_idx;
+    }
+    return true;
   }
 
-  lanelet::ConstLanelet best;
-  if (!lanelet::utils::query::getClosestLanelet(candidates, search_pose, &best)) {
+  // どのポリゴン内にも入っていない場合は最近傍で選択
+  lanelet::ConstLanelet closest;
+  if (!lanelet::utils::query::getClosestLanelet(route_lanelets_, search_pose, &closest)) {
     return false;
   }
-
-  *closest_lanelet = best;
-  auto it = route_index_map_.find(best.id());
+  RCLCPP_WARN(
+    logger_,
+    "getDrivingLanelet: pose (%.2f, %.2f) is outside all route lanelet polygons. "
+    "falling back to closest lanelet (id: %ld).",
+    search_pose.position.x, search_pose.position.y, closest.id());
+  *driving_lanelet = closest;
+  auto it = route_index_map_.find(closest.id());
   if (it != route_index_map_.end()) {
     last_closest_route_index_ = it->second;
   }
   return true;
-}
-
-bool RouteHandler::getNextLaneletWithinRoute(
-  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * next_lanelet) const
-{
-  if (exists(goal_lanelets_, lanelet)) {
-    return false;
-  }
-  const auto following_lanelets = routing_graph_ptr_->following(lanelet);
-  for (const auto & llt : following_lanelets) {
-    if (exists(route_lanelets_, llt)) {
-      *next_lanelet = llt;
-      return true;
-    }
-  }
-  return false;
 }
 
 bool RouteHandler::getNextLaneletWithinRoute(
@@ -824,6 +818,29 @@ lanelet::ConstLanelets RouteHandler::getPreviousLanelets(
   const lanelet::ConstLanelet & lanelet) const
 {
   return routing_graph_ptr_->previous(lanelet);
+}
+
+lanelet::ConstLanelets RouteHandler::getNextLanelets(
+  const lanelet::ConstLanelet & lanelet) const
+{
+  return routing_graph_ptr_->following(lanelet);
+}
+
+bool RouteHandler::getPreviousLaneletsWithinRoute(
+  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * prev_lanelets) const
+{
+  const lanelet::ConstLanelets previous_lanelets = routing_graph_ptr_->previous(lanelet);
+  if (previous_lanelets.empty()) {
+    return false;
+  }
+
+  for (const auto & llt : previous_lanelets) {
+    if (exists(route_lanelets_, llt)) {
+      prev_lanelets->push_back(llt);
+    }
+  }
+
+  return !prev_lanelets->empty();
 }
 
 lanelet::ConstLanelets RouteHandler::getLaneletsFromPoint(const lanelet::ConstPoint3d & point) const
@@ -1319,7 +1336,7 @@ bool RouteHandler::getPullOutStartLane(
 lanelet::ConstLanelets RouteHandler::getClosestLaneletSequence(const Pose & pose) const
 {
   lanelet::ConstLanelet lanelet;
-  if (!getClosestLaneletWithinRoute(pose, &lanelet)) {
+  if (!getDrivingLanelet(pose, &lanelet)) {
     return lanelet::ConstLanelets{};
   }
   return getLaneletSequence(lanelet);
@@ -1362,7 +1379,7 @@ int RouteHandler::getNumLaneToPreferredLane(
 bool RouteHandler::isInPreferredLane(const PoseStamped & pose) const
 {
   lanelet::ConstLanelet lanelet;
-  if (!getClosestLaneletWithinRoute(pose.pose, &lanelet)) {
+  if (!getDrivingLanelet(pose.pose, &lanelet)) {
     return false;
   }
   return exists(preferred_lanelets_, lanelet);
@@ -1371,7 +1388,7 @@ bool RouteHandler::isInTargetLane(
   const PoseStamped & pose, const lanelet::ConstLanelets & target) const
 {
   lanelet::ConstLanelet lanelet;
-  if (!getClosestLaneletWithinRoute(pose.pose, &lanelet)) {
+  if (!getDrivingLanelet(pose.pose, &lanelet)) {
     return false;
   }
   return exists(target, lanelet);
@@ -1468,7 +1485,7 @@ lanelet::ConstLanelets RouteHandler::getLaneChangeTargetLanes(const Pose & pose)
 {
   lanelet::ConstLanelet lanelet;
   lanelet::ConstLanelets target_lanelets;
-  if (!getClosestLaneletWithinRoute(pose, &lanelet)) {
+  if (!getDrivingLanelet(pose, &lanelet)) {
     return target_lanelets;
   }
 
@@ -1492,7 +1509,7 @@ double RouteHandler::getLaneChangeableDistance(
   const Pose & current_pose, const Direction & direction) const
 {
   lanelet::ConstLanelet current_lane;
-  if (!getClosestLaneletWithinRoute(current_pose, &current_lane)) {
+  if (!getDrivingLanelet(current_pose, &current_lane)) {
     return 0;
   }
 
@@ -1902,6 +1919,28 @@ lanelet::ConstLanelets RouteHandler::getMainLanelets(
     lanelet_sequence = getPreviousLaneletSequence(lanelet_sequence);
   }
   return main_lanelets;
+}
+
+void RouteHandler::setPublisher(rclcpp::Node * node)
+{
+  if (node != nullptr) {
+    lanelet_id_pub_ = node->create_publisher<std_msgs::msg::Int32>(
+      "/driving_lanelet_id", rclcpp::QoS(10));
+  }
+}
+
+void RouteHandler::publishDrivingLaneletId(const Pose & current_pose) const
+{
+  if (!lanelet_id_pub_) {
+    return;
+  }
+  lanelet::ConstLanelet driving_lanelet;
+  if (!getDrivingLanelet(current_pose, &driving_lanelet)) {
+    return;
+  }
+  std_msgs::msg::Int32 msg;
+  msg.data = static_cast<int32_t>(driving_lanelet.id());
+  lanelet_id_pub_->publish(msg);
 }
 
 }  // namespace route_handler

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -333,6 +333,11 @@ void RouteHandler::setLaneletsFromRouteMsg()
     }
   }
   is_handler_ready_ = true;
+  route_index_map_.clear();
+  for (size_t i = 0; i < route_lanelets_.size(); ++i) {
+    route_index_map_[route_lanelets_[i].id()] = i;
+  }
+  last_closest_route_index_.reset();
 }
 
 lanelet::ConstPolygon3d RouteHandler::getIntersectionAreaById(const lanelet::Id id) const
@@ -721,7 +726,46 @@ lanelet::ConstLanelets RouteHandler::getShoulderLaneletSequence(
 bool RouteHandler::getClosestLaneletWithinRoute(
   const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const
 {
-  return lanelet::utils::query::getClosestLanelet(route_lanelets_, search_pose, closest_lanelet);
+  std::vector<lanelet::ConstLanelet> candidates;
+  candidates.reserve(route_lanelets_.size());
+
+  for (const auto & llt : route_lanelets_) {
+    auto it = route_index_map_.find(llt.id());
+    if (it == route_index_map_.end()) {
+      continue;
+    }
+
+    if (last_closest_route_index_) {
+      const auto idx = it->second;
+      const auto last = *last_closest_route_index_;
+
+      // 飛びすぎ禁止
+      if (idx + 1 < last) {
+        continue;
+      }
+      if (idx > last + max_lane_jump_) {
+        continue;
+      }
+    }
+
+    candidates.push_back(llt);
+  }
+
+  if (candidates.empty()) {
+    candidates = route_lanelets_;
+  }
+
+  lanelet::ConstLanelet best;
+  if (!lanelet::utils::query::getClosestLanelet(candidates, search_pose, &best)) {
+    return false;
+  }
+
+  *closest_lanelet = best;
+  auto it = route_index_map_.find(best.id());
+  if (it != route_index_map_.end()) {
+    last_closest_route_index_ = it->second;
+  }
+  return true;
 }
 
 bool RouteHandler::getNextLaneletWithinRoute(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -761,6 +761,27 @@ bool RouteHandler::getDrivingLanelet(
   }
 
   // どのポリゴン内にも入っていない場合は最近傍で選択
+  // ただしスタートのlanelet（route_index=0）が1.5m以内なら優先的に返す
+  constexpr double start_lanelet_dist_threshold = 1.5;
+  for (const auto & llt : route_lanelets_) {
+    auto it = route_index_map_.find(llt.id());
+    if (it == route_index_map_.end() || it->second != 0) {
+      continue;
+    }
+    const double dist = boost::geometry::distance(llt.polygon2d().basicPolygon(), search_point);
+    if (dist <= start_lanelet_dist_threshold) {
+      RCLCPP_WARN(
+        logger_,
+        "getDrivingLanelet: pose (%.2f, %.2f) is outside all route lanelet polygons. "
+        "returning start lanelet (id: %ld, dist: %.3f).",
+        search_pose.position.x, search_pose.position.y, llt.id(), dist);
+      *driving_lanelet = llt;
+      last_closest_route_index_ = 0;
+      return true;
+    }
+    break;
+  }
+
   lanelet::ConstLanelet closest;
   if (!lanelet::utils::query::getClosestLanelet(route_lanelets_, search_pose, &closest)) {
     return false;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -784,25 +784,40 @@ bool RouteHandler::getNextLaneletWithinRoute(
   return false;
 }
 
-lanelet::ConstLanelets RouteHandler::getNextLanelets(const lanelet::ConstLanelet & lanelet) const
+bool RouteHandler::getNextLaneletWithinRoute(
+  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * next_lanelet) const
 {
-  return routing_graph_ptr_->following(lanelet);
-}
-
-bool RouteHandler::getPreviousLaneletsWithinRoute(
-  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * prev_lanelets) const
-{
-  if (exists(start_lanelets_, lanelet)) {
+  auto cur_it = route_index_map_.find(lanelet.id());
+  if (cur_it == route_index_map_.end()) {
     return false;
   }
-  const auto candidate_lanelets = routing_graph_ptr_->previous(lanelet);
-  prev_lanelets->clear();
-  for (const auto & llt : candidate_lanelets) {
-    if (exists(route_lanelets_, llt)) {
-      prev_lanelets->push_back(llt);
+  const auto cur_idx = cur_it->second;
+
+  bool found = false;
+  size_t best_idx = std::numeric_limits<size_t>::max();
+
+  for (const auto & llt : routing_graph_ptr_->following(lanelet)) {
+    if (!exists(route_lanelets_, llt)) {
+      continue;
+    }
+
+    auto it = route_index_map_.find(llt.id());
+    if (it == route_index_map_.end()) {
+      continue;
+    }
+
+    if (it->second <= cur_idx) {
+      continue;
+    }
+
+    if (it->second < best_idx) {
+      best_idx = it->second;
+      *next_lanelet = llt;
+      found = true;
     }
   }
-  return !(prev_lanelets->empty());
+
+  return found;
 }
 
 lanelet::ConstLanelets RouteHandler::getPreviousLanelets(


### PR DESCRIPTION
https://github.com/gekidaniino001/iino.universe/pull/1233

## 全体的な変更の思想
・mission_plannerは経路のgoalではなくルートのレーンid列を受け取るように変更。iinoは「特定のgoalに向かう機能」より「特定のルートを走行する機能」の方が重要
・車両が現在所属しているレーンidを一番近いレーンとしてしまうと数字の「6」のような経路を走るときにループできない可能性があるため、ルート上の点をスタートからたどり車両に近くなった点があればそこをレーンidとするように変更。（goal済の小経路のルートは削ってmission_plannerに投げる前提）

## mission_planner
/iino/lanelet_id_route トピックを新設し、lanelet ID列を直接受け取ってルートを生成できるように
外部ノード（BPPなど）が事前計算したルートを注入できる仕組み
## route_handler
getClosestLaneletWithinRoute を廃止し getDrivingLanelet に置き換え
ルート上のlanelet順序をインデックスで管理し、折り返しルートでの誤選択バグを修正
自車がポリゴン外の場合もスタートlanelet優先・最近傍フォールバックで対応
走行中のlanelet IDをトピックにパブリッシュする機能を追加
## behavior_path_planner
getDrivingLanelet への置き換えを全シーンモジュールに反映（avoidance, lane_following, side_shift等）
空パスが出た場合はパブリッシュをスキップしてクラッシュ防止
operation_mode のQoSを transient_local に変更し、起動時のラッチ取りこぼしを修正
自車がルートポリゴン外のときはデータ未準備扱いにして誤動作を抑制
## tier4_planning_launch
behavior_planningのマルチスレッドを true → false に変更（データ競合・不安定動作の回避）